### PR TITLE
feat: database cache config with evmJsonRpcCache (Issue #24)

### DIFF
--- a/erpc/config.py
+++ b/erpc/config.py
@@ -14,11 +14,12 @@ from erpc.exceptions import ERPCConfigError
 
 if TYPE_CHECKING:
     from erpc.auth import AuthConfig
-    from erpc.database import DatabaseConfig
     from erpc.networks import NetworkConfig
     from erpc.providers import Provider
     from erpc.server import MetricsConfig, ServerConfig
     from erpc.upstreams import UpstreamConfig
+
+from erpc.database import CachePolicy, DatabaseConfig, MemoryConnector
 
 
 @dataclass
@@ -75,7 +76,7 @@ class ERPCConfig:
     server: ServerConfig | None = None
     metrics: MetricsConfig | None = None
     auth: AuthConfig | None = None
-    database: DatabaseConfig | None = None
+    database: DatabaseConfig | None = None  # explicit database config overrides auto-generation
     networks: list[NetworkConfig] = field(default_factory=list)
     network_defaults: NetworkConfig | None = None
     upstream_defaults: UpstreamConfig | None = None
@@ -258,6 +259,11 @@ class ERPCConfig:
             "metrics": metrics_dict,
             "projects": [self._build_project()],
         }
+
+        db_config = self._resolve_database()
+        if db_config is not None:
+            doc["database"] = {"evmJsonRpcCache": db_config.to_dict()}
+
         return yaml.dump(doc, default_flow_style=False, sort_keys=False)
 
     def write(self, path: Path | None = None) -> Path:
@@ -310,9 +316,6 @@ class ERPCConfig:
                     "evm": {"chainId": chain_id},
                 }
 
-            if self.cache.method_ttls:
-                network["policies"] = self._build_cache_policies()
-
             networks.append(network)
 
         project: dict[str, Any] = {
@@ -333,32 +336,53 @@ class ERPCConfig:
         if self.providers:
             project["providers"] = [p.to_dict() for p in self.providers]
 
-        if self.database is not None:
-            project["database"] = self.database.to_dict()
-
         if self.auth is not None:
             project["auth"] = self.auth.to_dict()
 
         return project
 
-    def _build_cache_policies(self) -> list[dict[str, Any]]:
-        """Build cache policy rules from method TTL overrides."""
-        policies: list[dict[str, Any]] = []
+    def _resolve_database(self) -> DatabaseConfig | None:
+        """Resolve the effective database config.
+
+        Returns the explicit ``database`` if set, otherwise auto-generates
+        one from ``CacheConfig.method_ttls``.
+        """
+        if self.database is not None:
+            return self.database
+
+        if not self.cache.method_ttls:
+            return None
+
+        connector = MemoryConnector(id="memory-cache", max_items=self.cache.max_items)
+
+        # Default policies: finalized=0 (no cache), unfinalized=5s
+        policies: list[CachePolicy] = [
+            CachePolicy(
+                connector="memory-cache",
+                ttl="0",
+                network="*",
+                method="*",
+                finality="finalized",
+            ),
+            CachePolicy(
+                connector="memory-cache",
+                ttl="5s",
+                network="*",
+                method="*",
+                finality="unfinalized",
+            ),
+        ]
+
+        # Per-method overrides
         for method, ttl in self.cache.method_ttls.items():
-            if ttl == 0:
-                policies.append(
-                    {
-                        "method": method,
-                        "finality": "unfinalized",
-                        "cache": {"empty": "skip", "ttl": "0s"},
-                    }
+            policies.append(
+                CachePolicy(
+                    connector="memory-cache",
+                    ttl=f"{ttl}s",
+                    network="*",
+                    method=method,
+                    finality="unfinalized",
                 )
-            else:
-                policies.append(
-                    {
-                        "method": method,
-                        "finality": "unfinalized",
-                        "cache": {"ttl": f"{ttl}s"},
-                    }
-                )
-        return policies
+            )
+
+        return DatabaseConfig(connectors=[connector], policies=policies)

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -310,3 +310,42 @@ class TestHealthViaClient:
         """ERPCClient.is_healthy returns True for a running instance."""
         client = erpc_process.client
         assert client.is_healthy
+
+
+class TestDatabaseCacheConfig:
+    """Validate that eRPC accepts configs with database cache section."""
+
+    def test_starts_with_cache_config(self, erpc_binary: str, mock_upstream: MockUpstream) -> None:
+        """eRPC binary starts and becomes healthy with database cache policies."""
+        from erpc.config import CacheConfig
+
+        cache = CacheConfig(
+            max_items=10000,
+            method_ttls={
+                "eth_call": 0,
+                "eth_getLogs": 2,
+                "eth_blockNumber": 4,
+                "eth_gasPrice": 4,
+            },
+        )
+        config = ERPCConfig(
+            upstreams={1: [mock_upstream.url]},
+            server_port=14100,
+            metrics_port=14101,
+            cache=cache,
+        )
+
+        # Verify database section is in the generated config
+        yaml_output = config.to_yaml()
+        assert "database:" in yaml_output
+        assert "evmJsonRpcCache:" in yaml_output
+        assert "memory-cache" in yaml_output
+
+        proc = ERPCProcess(config=config, binary_path=erpc_binary)
+        try:
+            proc.start()
+            proc.wait_for_health(timeout=30)
+            assert proc.is_running, "eRPC should be running with database cache config"
+        finally:
+            if proc.is_running:
+                proc.stop()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -91,15 +91,20 @@ def test_method_ttl_overrides():
         ),
     )
     doc = yaml.safe_load(config.to_yaml())
-    network = doc["projects"][0]["networks"][0]
-    policies = network["policies"]
 
-    assert len(policies) == 2
+    # Policies now live under top-level database.evmJsonRpcCache
+    assert "database" in doc
+    cache_section = doc["database"]["evmJsonRpcCache"]
+    policies = cache_section["policies"]
+
+    # 2 default policies + 2 method overrides
+    assert len(policies) == 4
+
     eth_call_policy = next(p for p in policies if p["method"] == "eth_call")
-    assert eth_call_policy["cache"]["ttl"] == "0s"
+    assert eth_call_policy["ttl"] == "0s"
 
     eth_logs_policy = next(p for p in policies if p["method"] == "eth_getLogs")
-    assert eth_logs_policy["cache"]["ttl"] == "2s"
+    assert eth_logs_policy["ttl"] == "2s"
 
 
 def test_write_to_path(tmp_path):
@@ -129,3 +134,102 @@ def test_custom_ports():
     doc = yaml.safe_load(config.to_yaml())
     assert doc["server"]["httpPort"] == 8080
     assert doc["metrics"]["port"] == 8081
+
+
+# --- Database cache config tests ---
+
+
+def test_no_database_without_cache():
+    """ERPCConfig without method_ttls should not emit database section."""
+    config = ERPCConfig(upstreams={1: ["https://rpc.example.com"]})
+    doc = yaml.safe_load(config.to_yaml())
+    assert "database" not in doc
+
+
+def test_database_auto_generated_from_method_ttls():
+    """method_ttls should auto-generate top-level database with evmJsonRpcCache."""
+    config = ERPCConfig(
+        upstreams={1: ["https://rpc.example.com"]},
+        cache=CacheConfig(max_items=100_000, method_ttls={"eth_call": 0}),
+    )
+    doc = yaml.safe_load(config.to_yaml())
+    assert "database" in doc
+    cache_section = doc["database"]["evmJsonRpcCache"]
+
+    # Connector
+    connectors = cache_section["connectors"]
+    assert len(connectors) == 1
+    assert connectors[0]["id"] == "memory-cache"
+    assert connectors[0]["driver"] == "memory"
+    assert connectors[0]["memory"]["maxItems"] == 100_000
+
+    # Default policies
+    policies = cache_section["policies"]
+    finalized = next(p for p in policies if p["finality"] == "finalized" and p["method"] == "*")
+    assert str(finalized["ttl"]) == "0"
+
+    unfinalized = next(
+        p for p in policies if p["finality"] == "unfinalized" and p["method"] == "*"
+    )
+    assert unfinalized["ttl"] == "5s"
+
+
+def test_method_ttl_zero_produces_0s():
+    """TTL=0 should emit ttl: 0s for the method override."""
+    config = ERPCConfig(
+        upstreams={1: ["https://rpc.example.com"]},
+        cache=CacheConfig(method_ttls={"eth_call": 0}),
+    )
+    doc = yaml.safe_load(config.to_yaml())
+    policies = doc["database"]["evmJsonRpcCache"]["policies"]
+    eth_call = next(p for p in policies if p["method"] == "eth_call")
+    assert eth_call["ttl"] == "0s"
+    assert eth_call["finality"] == "unfinalized"
+
+
+def test_explicit_database_overrides_auto():
+    """Explicit DatabaseConfig should take precedence over auto-generation."""
+    from erpc.database import CachePolicy as DBCachePolicy
+    from erpc.database import DatabaseConfig, MemoryConnector
+
+    db = DatabaseConfig(
+        connectors=[MemoryConnector(id="custom", max_items=5000)],
+        policies=[DBCachePolicy(connector="custom", ttl="60s", finality="finalized")],
+    )
+    config = ERPCConfig(
+        upstreams={1: ["https://rpc.example.com"]},
+        cache=CacheConfig(method_ttls={"eth_call": 0}),
+        database=db,
+    )
+    doc = yaml.safe_load(config.to_yaml())
+    connectors = doc["database"]["evmJsonRpcCache"]["connectors"]
+    assert connectors[0]["id"] == "custom"
+
+
+def test_database_not_under_project():
+    """database should be at top level, not under projects."""
+    config = ERPCConfig(
+        upstreams={1: ["https://rpc.example.com"]},
+        cache=CacheConfig(method_ttls={"eth_call": 0}),
+    )
+    doc = yaml.safe_load(config.to_yaml())
+    assert "database" not in doc["projects"][0]
+    assert "database" in doc
+
+
+def test_database_round_trip():
+    """Generate YAML with database, parse back, verify structure."""
+    config = ERPCConfig(
+        upstreams={1: ["https://rpc.example.com"]},
+        cache=CacheConfig(max_items=50_000, method_ttls={"eth_getBalance": 10}),
+    )
+    yaml_str = config.to_yaml()
+    doc = yaml.safe_load(yaml_str)
+
+    db = doc["database"]["evmJsonRpcCache"]
+    assert len(db["connectors"]) == 1
+    assert len(db["policies"]) == 3  # 2 defaults + 1 override
+    assert db["connectors"][0]["memory"]["maxItems"] == 50_000
+
+    override = next(p for p in db["policies"] if p["method"] == "eth_getBalance")
+    assert override["ttl"] == "10s"


### PR DESCRIPTION
## Summary

Fixes #24 — eRPC expects cache policies under a top-level `database` section with `evmJsonRpcCache`, not under `networks`.

### Changes

- Auto-generate `DatabaseConfig` from `CacheConfig.method_ttls` with memory connector + default policies
- Emit `database.evmJsonRpcCache` at YAML top level (not under project)
- Default policies: `finalized` → ttl 0, `unfinalized` → ttl 5s
- Per-method TTL overrides (`TTL=0` → `0s`)
- Explicit `DatabaseConfig` overrides auto-generation
- Removed broken `_build_cache_policies()` method

### Expected YAML output

```yaml
database:
  evmJsonRpcCache:
    connectors:
      - id: memory-cache
        driver: memory
        memory:
          maxItems: 100000
    policies:
      - connector: memory-cache
        ttl: 0
        network: "*"
        method: "*"
        finality: finalized
      - connector: memory-cache
        ttl: 5s
        network: "*"
        method: "*"
        finality: unfinalized
      - connector: memory-cache
        ttl: 0s
        network: "*"
        method: eth_call
        finality: unfinalized
```

### Tests

- 7 new unit tests covering serialization, auto-generation, round-trip, and edge cases
- All 477 unit tests pass
- Lint, format, and mypy clean